### PR TITLE
fix: fix bug with target currency not updating

### DIFF
--- a/src/components/NumberInput.tsx
+++ b/src/components/NumberInput.tsx
@@ -43,7 +43,7 @@ const NumberInput = ({
     // without this, the currency symbol changes only after onBlurLocal runs.
     if (isMounted.current) {
       // whenever we change currency we also want to update shown value
-      numberToText(lastValue);
+      numberToText(+defaultValue || lastValue);
     }
   }, [localeOptions.currency]);
 


### PR DESCRIPTION
currently, if you select a different target currency, the calculation won't be updated – only the currency symbol. 

this is a regression I introduced when adding the new useEffect which fixed the currency symbol not updating.

this PR fixes it by first evaluating `defaultValue` (new calculation) -- the `lastValue` will be a fallback that triggers when `defaultValue` is undefined.

**NOTE**: I'm not merging that as current code-base is on freeze.

**TODO**:

- [x] Merge
- [ ] Add tests + regression test for this case.